### PR TITLE
packed storage compatability

### DIFF
--- a/src/main/resources/data/c/tags/blocks/chest.json
+++ b/src/main/resources/data/c/tags/blocks/chest.json
@@ -1,0 +1,15 @@
+{
+  "replace": "false",
+  "values": [
+    "packed:oak_chest_default",
+    "packed:spruce_chest_default",
+    "packed:birch_chest_default",
+    "packed:acacia_chest_default",
+    "packed:jungle_chest_default",
+    "packed:dark_oak_chest_default",
+    "packed:crimson_chest_default",
+    "packed:warped_chest_default",
+    "minecraft:chest",
+    "minecraft:trapped_chest"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/chest.json
+++ b/src/main/resources/data/c/tags/items/chest.json
@@ -1,0 +1,15 @@
+{
+  "replace": "false",
+  "values": [
+    "packed:oak_chest_default",
+    "packed:spruce_chest_default",
+    "packed:birch_chest_default",
+    "packed:acacia_chest_default",
+    "packed:jungle_chest_default",
+    "packed:dark_oak_chest_default",
+    "packed:crimson_chest_default",
+    "packed:warped_chest_default",
+    "minecraft:chest",
+    "minecraft:trapped_chest"
+  ]
+}

--- a/src/main/resources/data/woodenhoppers/recipes/acacia_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/acacia_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"a": {
 			"item": "minecraft:acacia_planks"

--- a/src/main/resources/data/woodenhoppers/recipes/birch_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/birch_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"b": {
 			"item": "minecraft:birch_planks"

--- a/src/main/resources/data/woodenhoppers/recipes/crimson_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/crimson_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"c": {
 			"item": "minecraft:crimson_planks"

--- a/src/main/resources/data/woodenhoppers/recipes/dark_oak_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/dark_oak_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"d": {
 			"item": "minecraft:dark_oak_planks"

--- a/src/main/resources/data/woodenhoppers/recipes/jungle_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/jungle_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"j": {
 			"item": "minecraft:jungle_planks"

--- a/src/main/resources/data/woodenhoppers/recipes/oak_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/oak_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"o": {
 			"item": "minecraft:oak_planks"

--- a/src/main/resources/data/woodenhoppers/recipes/spruce_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/spruce_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"s": {
 			"item": "minecraft:spruce_planks"

--- a/src/main/resources/data/woodenhoppers/recipes/warped_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/warped_hopper.json
@@ -8,7 +8,7 @@
 	],
 	"key": {
 		"C": {
-			"item": "minecraft:chest"
+			"tag": "c:chest"
 		},
 		"w": {
 			"item": "minecraft:warped_planks"


### PR DESCRIPTION
adds the ability to craft wooden hoppers using packed storage's chests, since the mod makes the vanilla chest uncraftable.
this will make any type of packed chest work for any of the recipes, with the outcome depending on the planks used. you may want to fix that, but for myself this is good enough.

im not familiar with modding, so i dont know if this will cause a crash or any problems if used without packed storage.