### PR TITLE
Optional depenency + Sakura Hopper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Wooden Hoppers requires the [Fabric modloader](https://fabricmc.net/use/) and [F
 This mod adds wooden hoppers for each type of wood. Their crafting recipe is similar to normal hoppers, but use planks rather than iron ingots.
 
 These hoppers can only contain one stack of items and have a cooldown of 12 ticks rather than 8 ticks.
+
+## Optional Mods
+* Install [Sakura Rosea](https://www.curseforge.com/minecraft/mc-mods/sakura-rosea/) to get a Sakura-hopper.

--- a/src/main/java/io/github/haykam821/woodenhoppers/Main.java
+++ b/src/main/java/io/github/haykam821/woodenhoppers/Main.java
@@ -14,17 +14,11 @@ public class Main implements ModInitializer {
 	public static final String MOD_ID = "woodenhoppers";
 
 	private static final Identifier WOODEN_HOPPER_ID = new Identifier(MOD_ID, "wooden_hopper");
+
 	public static final BlockEntityType<WoodenHopperBlockEntity> WOODEN_HOPPER_BLOCK_ENTITY_TYPE = BlockEntityType.Builder
 		.create(
 			WoodenHopperBlockEntity::new,
-			ModBlocks.OAK_HOPPER.getBlock(),
-			ModBlocks.SPRUCE_HOPPER.getBlock(),
-			ModBlocks.BIRCH_HOPPER.getBlock(),
-			ModBlocks.JUNGLE_HOPPER.getBlock(),
-			ModBlocks.ACACIA_HOPPER.getBlock(),
-			ModBlocks.DARK_OAK_HOPPER.getBlock(),
-			ModBlocks.CRIMSON_HOPPER.getBlock(),
-			ModBlocks.WARPED_HOPPER.getBlock()
+			ModBlocks.getBlocks()
 		)
 		.build(null);
 

--- a/src/main/java/io/github/haykam821/woodenhoppers/Main.java
+++ b/src/main/java/io/github/haykam821/woodenhoppers/Main.java
@@ -15,7 +15,17 @@ public class Main implements ModInitializer {
 
 	private static final Identifier WOODEN_HOPPER_ID = new Identifier(MOD_ID, "wooden_hopper");
 	public static final BlockEntityType<WoodenHopperBlockEntity> WOODEN_HOPPER_BLOCK_ENTITY_TYPE = BlockEntityType.Builder
-		.create(WoodenHopperBlockEntity::new, ModBlocks.OAK_HOPPER.getBlock(), ModBlocks.SPRUCE_HOPPER.getBlock(), ModBlocks.BIRCH_HOPPER.getBlock(), ModBlocks.JUNGLE_HOPPER.getBlock(), ModBlocks.ACACIA_HOPPER.getBlock(), ModBlocks.DARK_OAK_HOPPER.getBlock(), ModBlocks.CRIMSON_HOPPER.getBlock(), ModBlocks.WARPED_HOPPER.getBlock())
+		.create(
+			WoodenHopperBlockEntity::new,
+			ModBlocks.OAK_HOPPER.getBlock(),
+			ModBlocks.SPRUCE_HOPPER.getBlock(),
+			ModBlocks.BIRCH_HOPPER.getBlock(),
+			ModBlocks.JUNGLE_HOPPER.getBlock(),
+			ModBlocks.ACACIA_HOPPER.getBlock(),
+			ModBlocks.DARK_OAK_HOPPER.getBlock(),
+			ModBlocks.CRIMSON_HOPPER.getBlock(),
+			ModBlocks.WARPED_HOPPER.getBlock()
+		)
 		.build(null);
 
 	public static final ScreenHandlerType<WoodenHopperScreenHandler> WOODEN_HOPPER_SCREEN_HANDLER_TYPE = ScreenHandlerRegistry.registerSimple(WOODEN_HOPPER_ID, WoodenHopperScreenHandler::new);

--- a/src/main/java/io/github/haykam821/woodenhoppers/block/ModBlocks.java
+++ b/src/main/java/io/github/haykam821/woodenhoppers/block/ModBlocks.java
@@ -1,6 +1,8 @@
 package io.github.haykam821.woodenhoppers.block;
 
 import io.github.haykam821.woodenhoppers.Main;
+import java.util.HashSet;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.Material;
@@ -19,6 +21,7 @@ public enum ModBlocks {
 	ACACIA_HOPPER("acacia_hopper", Material.WOOD, Blocks.OAK_PLANKS),
 	DARK_OAK_HOPPER("dark_oak_hopper", Material.WOOD, Blocks.OAK_PLANKS),
 	CRIMSON_HOPPER("crimson_hopper", Material.NETHER_WOOD, Blocks.OAK_PLANKS),
+	SAKURA_HOPPER("sakura_hopper", Material.WOOD, Blocks.OAK_PLANKS, "sakurarosea"),
 	WARPED_HOPPER("warped_hopper", Material.NETHER_WOOD, Blocks.OAK_PLANKS);
 
 	private final Block block;
@@ -28,14 +31,51 @@ public enum ModBlocks {
 		Identifier id = new Identifier(Main.MOD_ID, path);
 
 		this.block = block;
+
+		if (block == null) {
+			this.item = null;
+			return;
+		}
+
 		Registry.register(Registry.BLOCK, id, block);
 
 		this.item = new BlockItem(block, new Item.Settings().group(ItemGroup.REDSTONE));
 		Registry.register(Registry.ITEM, id, this.item);
 	}
 
+	private ModBlocks(String path, Material material, Block base, String requiredMod) {
+		this(
+			path,
+			FabricLoader.getInstance().isModLoaded(requiredMod) ?
+				new WoodenHopperBlock(
+					Block.Settings.of(
+						material,
+						base
+							.getDefaultMaterialColor()
+					)
+						.strength(2)
+						.sounds(BlockSoundGroup.WOOD)
+						.nonOpaque()
+				)
+			:
+				null
+		);
+	}
+
 	private ModBlocks(String path, Material material, Block base) {
-		this(path, new WoodenHopperBlock(Block.Settings.of(material, base.getDefaultMaterialColor()).strength(2).sounds(BlockSoundGroup.WOOD).nonOpaque()));
+		this(
+			path,
+			new WoodenHopperBlock(
+				Block.Settings.of(
+					material,
+					base
+						.getDefaultMaterialColor()
+				)
+					.strength(2)
+					.sounds(BlockSoundGroup.WOOD)
+					.nonOpaque()
+			)
+		);
 	}
 
 	public Block getBlock() {
@@ -47,6 +87,16 @@ public enum ModBlocks {
 	}
 
 	public static void initialize() {
-		return;
+	}
+
+	public static Block[] getBlocks() {
+		HashSet<Block> list = new HashSet<>();
+		for(ModBlocks mb : values()) {
+			if(mb.block != null) {
+				list.add(mb.block);
+			}
+		}
+		Block[] array = new Block[list.size()];
+		return list.toArray(array);
 	}
 }

--- a/src/main/resources/assets/woodenhoppers/blockstates/sakura_hopper.json
+++ b/src/main/resources/assets/woodenhoppers/blockstates/sakura_hopper.json
@@ -1,0 +1,22 @@
+{
+	"variants": {
+		"facing=down": {
+			"model": "woodenhoppers:block/sakura_hopper"
+		},
+		"facing=east": {
+			"model": "woodenhoppers:block/sakura_hopper_side",
+			"y": 90
+		},
+		"facing=north": {
+			"model": "woodenhoppers:block/sakura_hopper_side"
+		},
+		"facing=south": {
+			"model": "woodenhoppers:block/sakura_hopper_side",
+			"y": 180
+		},
+		"facing=west": {
+			"model": "woodenhoppers:block/sakura_hopper_side",
+			"y": 270
+		}
+	}
+}

--- a/src/main/resources/assets/woodenhoppers/lang/en_us.json
+++ b/src/main/resources/assets/woodenhoppers/lang/en_us.json
@@ -7,5 +7,6 @@
 	"block.woodenhoppers.oak_hopper": "Oak Hopper",
 	"block.woodenhoppers.spruce_hopper": "Spruce Hopper",
 	"block.woodenhoppers.warped_hopper": "Warped Hopper",
+	"block.woodenhoppers.sakura_hopper": "Sakura Hopper",
 	"container.wooden_hopper": "Wooden Hopper"
 }

--- a/src/main/resources/assets/woodenhoppers/models/block/sakura_hopper.json
+++ b/src/main/resources/assets/woodenhoppers/models/block/sakura_hopper.json
@@ -1,0 +1,6 @@
+{
+	"parent": "woodenhoppers:block/wooden_hopper",
+	"textures": {
+		"all": "sakurarosea:blocks/sakura_planks"
+	}
+}

--- a/src/main/resources/assets/woodenhoppers/models/block/sakura_hopper_side.json
+++ b/src/main/resources/assets/woodenhoppers/models/block/sakura_hopper_side.json
@@ -1,0 +1,9 @@
+{
+	"parent": "block/hopper_side",
+	"textures": {
+		"particle": "sakurarosea:blocks/sakura_planks",
+		"top": "sakurarosea:blocks/sakura_planks",
+		"side": "sakurarosea:blocks/sakura_planks",
+		"inside": "sakurarosea:blocks/sakura_planks"
+	}
+}

--- a/src/main/resources/assets/woodenhoppers/models/item/sakura_hopper.json
+++ b/src/main/resources/assets/woodenhoppers/models/item/sakura_hopper.json
@@ -1,0 +1,3 @@
+{
+	"parent": "woodenhoppers:block/sakura_hopper"
+}

--- a/src/main/resources/data/woodenhoppers/advancements/recipes/sakura_hopper.json
+++ b/src/main/resources/data/woodenhoppers/advancements/recipes/sakura_hopper.json
@@ -1,0 +1,32 @@
+{
+	"parent": "minecraft:recipes/root",
+	"rewards": {
+		"recipes": [
+			"woodenhoppers:sakura_hopper"
+		]
+	},
+	"criteria": {
+		"has_sakura_planks": {
+			"trigger": "minecraft:inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"item": "minecraft:sakura_planks"
+					}
+				]
+			}
+		},
+		"has_the_recipe": {
+			"trigger": "minecraft:recipe_unlocked",
+			"conditions": {
+				"recipe": "woodenhoppers:sakura_hopper"
+			}
+		}
+	},
+	"requirements": [
+		[
+			"has_sakura_planks",
+			"has_the_recipe"
+		]
+	]
+}

--- a/src/main/resources/data/woodenhoppers/loot_tables/blocks/sakura_hopper.json
+++ b/src/main/resources/data/woodenhoppers/loot_tables/blocks/sakura_hopper.json
@@ -1,0 +1,25 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"functions": [
+						{
+							"function": "minecraft:copy_name",
+							"source": "block_entity"
+						}
+					],
+					"name": "woodenhoppers:sakura_hopper"
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:survives_explosion"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/woodenhoppers/recipes/sakura_chest_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/sakura_chest_hopper.json
@@ -1,0 +1,20 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"group": "woodenhoppers:wooden_hopper",
+	"pattern": [
+		"w w",
+		"wCw",
+		" w "
+	],
+	"key": {
+		"C": {
+			"item": "sakurarosea:sakura_chest"
+		},
+		"w": {
+			"tag": "minecraft:planks"
+		}
+	},
+	"result": {
+		"item": "woodenhoppers:sakura_hopper"
+	}
+}

--- a/src/main/resources/data/woodenhoppers/recipes/sakura_hopper.json
+++ b/src/main/resources/data/woodenhoppers/recipes/sakura_hopper.json
@@ -1,0 +1,20 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"group": "woodenhoppers:wooden_hopper",
+	"pattern": [
+		"w w",
+		"wCw",
+		" w "
+	],
+	"key": {
+		"C": {
+			"item": "minecraft:chest"
+		},
+		"w": {
+			"item": "sakurarosea:sakura_planks"
+		}
+	},
+	"result": {
+		"item": "woodenhoppers:sakura_hopper"
+	}
+}

--- a/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
@@ -7,6 +7,7 @@
 		"woodenhoppers:acacia_hopper",
 		"woodenhoppers:dark_oak_hopper",
 		"woodenhoppers:crimson_hopper",
-		"woodenhoppers:warped_hopper"
+		"woodenhoppers:warped_hopper",
+		"woodenhoppers:sakura_hopper"
 	]
 }

--- a/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
@@ -7,6 +7,7 @@
 		"woodenhoppers:acacia_hopper",
 		"woodenhoppers:dark_oak_hopper",
 		"woodenhoppers:crimson_hopper",
-		"woodenhoppers:warped_hopper"
+		"woodenhoppers:warped_hopper",
+		"woodenhoppers:sakura_hopper"
 	]
 }


### PR DESCRIPTION
Add support for optional loading blocks depending on what mods are loaded.

Load the Sakura Hopper if the Sakura mod is loaded.

![sakura_hopper](https://user-images.githubusercontent.com/866668/103566522-6cbed600-4ec2-11eb-948c-2c2e536f3167.png)
